### PR TITLE
CRD not rendering due to yq bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
          version: ${{ inputs.helm-version }} # default is latest (stable)
       id: install
       
-    - name: Set foobar to cool
+    - name: Install yq
       uses: mikefarah/yq@v4.27.5
 
     - name: Set Git Author

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,9 @@ runs:
       with:
          version: ${{ inputs.helm-version }} # default is latest (stable)
       id: install
+      
+    - name: Set foobar to cool
+      uses: mikefarah/yq@v4.27.5
 
     - name: Set Git Author
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -81,12 +81,12 @@ runs:
       with:
         version: ${{ inputs.version }}
         sha256-checksum: ${{ inputs.sha256-checksum }}
-        
+
     - uses: azure/setup-helm@v3
       with:
-         version: ${{ inputs.helm-version }} # default is latest (stable)
+        version: ${{ inputs.helm-version }}   # default is latest (stable)
       id: install
-      
+
     - name: Install yq
       uses: mikefarah/yq@v4.27.5
 
@@ -123,13 +123,12 @@ runs:
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
+        comment-author: github-actions[bot]
         body-includes: Comparison of ${{env.DIFF_BRANCH}}
 
     - name: Create or update comment with No Changes
-      if: ${{ github.event_name == 'pull_request' &&
-        steps.fc.outputs.comment-id != 0 &&
-        steps.diff.outputs.diff-bytes == 0 }}
+      if: ${{ github.event_name == 'pull_request' && steps.fc.outputs.comment-id !=
+        0 && steps.diff.outputs.diff-bytes == 0 }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -141,9 +140,8 @@ runs:
         edit-mode: replace
 
     - name: Create or update comment with Diff
-      if: ${{ github.event_name == 'pull_request' &&
-        steps.diff.outputs.diff-bytes > 0 &&
-        steps.diff.outputs.diff-bytes < 65000 }}
+      if: ${{ github.event_name == 'pull_request' && steps.diff.outputs.diff-bytes
+        > 0 && steps.diff.outputs.diff-bytes < 65000 }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -161,8 +159,8 @@ runs:
         edit-mode: replace
 
     - name: Create or update comment with Too Big Diff
-      if: ${{ github.event_name == 'pull_request' &&
-        steps.diff.outputs.diff-bytes >= 65000 }}
+      if: ${{ github.event_name == 'pull_request' && steps.diff.outputs.diff-bytes
+        >= 65000 }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -178,8 +176,7 @@ runs:
     - name: Commit to ${{ env.PUSH_BRANCH }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      if: ${{ inputs.dry-run == 'false' &&
-        env.DEPLOY_METHOD == 'push' }}
+      if: ${{ inputs.dry-run == 'false' && env.DEPLOY_METHOD == 'push' }}
       run: |
         if ! git diff --quiet origin/${DIFF_BRANCH} ; then
           if [ -n "${GIT_COMMIT_MESSAGE}" ]; then
@@ -211,8 +208,7 @@ runs:
     - name: Open Deployment PR to ${{ inputs.environment }}
       id: open-pr
       uses: peter-evans/create-pull-request@v4
-      if: ${{ inputs.dry-run == 'false' &&
-        env.DEPLOY_METHOD == 'pull-request' &&
+      if: ${{ inputs.dry-run == 'false' && env.DEPLOY_METHOD == 'pull-request' &&
         steps.diff.outputs.diff-bytes > 0 }}
       with:
         title: Deployment to ${{ inputs.environment }}
@@ -223,9 +219,9 @@ runs:
         path: ${{ inputs.working-directory }}
 
     - name: PR Opened or Updated
-      if: ${{ steps.open-pr.outputs.pull-request-number &&
-        (steps.open-pr.outputs.pull-request-operation == 'created' ||
-          steps.open-pr.outputs.pull-request-operation == 'updated') }}
+      if: ${{ steps.open-pr.outputs.pull-request-number && (steps.open-pr.outputs.pull-request-operation
+        == 'created' || steps.open-pr.outputs.pull-request-operation == 'updated')
+        }}
       shell: bash
       run: |
         echo "The deployment PR for ${{ inputs.environment }} is waiting for
@@ -235,10 +231,10 @@ runs:
         echo "${{ steps.cpr.outputs.pull-request-url }}"
 
     - name: PR Closed
-      if: ${{ steps.open-pr.outputs.pull-request-number &&
-        steps.open-pr.outputs.pull-request-operation == 'closed' }}
+      if: ${{ steps.open-pr.outputs.pull-request-number && steps.open-pr.outputs.pull-request-operation
+        == 'closed' }}
       shell: bash
-      run: |
+      run: |-
         echo "The deployment PR for ${{ inputs.environment }} has been closed as
           there are no changes detected."
         echo "${{ steps.cpr.outputs.pull-request-url }}"

--- a/kustomize-build.sh
+++ b/kustomize-build.sh
@@ -13,9 +13,12 @@ kustomize edit add buildmetadata originAnnotations,managedByLabel
 popd || exit 1
 
 kustomize build --enable-helm "${ENV_DIR}" > /tmp/all.yaml
-
+echo "/tmp/all contents:"
+cat /tmp/all.yaml
 pushd /tmp || exit 1
 yq -s '.kind + "-" + (.apiVersion | sub("\/", "_")) + "-" + .metadata.name' < all.yaml
+echo "ls in /tmp after split:"
+ls -a
 rm all.yaml
 popd || exit 1
 

--- a/kustomize-build.sh
+++ b/kustomize-build.sh
@@ -17,7 +17,7 @@ echo "/tmp/all contents:"
 cat /tmp/all.yaml
 pushd /tmp || exit 1
 yq --version
-yq -s '.kind + "-" + .metadata.name' < all.yaml
+yq -s '.kind + "-" + .metadata.name + ".yaml"' < all.yaml
 echo "ls in /tmp after split:"
 ls -a
 rm all.yaml

--- a/kustomize-build.sh
+++ b/kustomize-build.sh
@@ -16,6 +16,7 @@ kustomize build --enable-helm "${ENV_DIR}" > /tmp/all.yaml
 echo "/tmp/all contents:"
 cat /tmp/all.yaml
 pushd /tmp || exit 1
+yq --version
 yq -s '.kind + "-" + (.apiVersion | sub("\/", "_")) + "-" + .metadata.name' < all.yaml
 echo "ls in /tmp after split:"
 ls -a

--- a/kustomize-build.sh
+++ b/kustomize-build.sh
@@ -13,13 +13,9 @@ kustomize edit add buildmetadata originAnnotations,managedByLabel
 popd || exit 1
 
 kustomize build --enable-helm "${ENV_DIR}" > /tmp/all.yaml
-echo "/tmp/all contents:"
-cat /tmp/all.yaml
+
 pushd /tmp || exit 1
-yq --version
 yq -s '.kind + "-" + .metadata.name + ".yaml"' < all.yaml
-echo "ls in /tmp after split:"
-ls -a
 rm all.yaml
 popd || exit 1
 

--- a/kustomize-build.sh
+++ b/kustomize-build.sh
@@ -17,7 +17,7 @@ echo "/tmp/all contents:"
 cat /tmp/all.yaml
 pushd /tmp || exit 1
 yq --version
-yq -s '.kind + "-" + (.apiVersion | sub("\/", "_")) + "-" + .metadata.name' < all.yaml
+yq -s '.kind + "-" + .metadata.name' < all.yaml
 echo "ls in /tmp after split:"
 ls -a
 rm all.yaml

--- a/kustomize-build.sh
+++ b/kustomize-build.sh
@@ -15,7 +15,7 @@ popd || exit 1
 kustomize build --enable-helm "${ENV_DIR}" > /tmp/all.yaml
 
 pushd /tmp || exit 1
-yq -s '.kind + "-" + .metadata.name + ".yaml"' < all.yaml
+yq -s '.kind + "-" + (.apiVersion | sub("\/", "_")) + "-" + .metadata.name + ".yaml"' < all.yaml
 rm all.yaml
 popd || exit 1
 


### PR DESCRIPTION
Fixes an issue with how yq was splitting the yaml previously. Attempting to split out a particular CRD was not adding the `.yml` extension, but upgrading to the latest YQ and specifying that I want the `.yaml` file extension explicitly in the expression seems to have resolved that issue.

See issue https://github.com/mikefarah/yq/issues/1165