### PR TITLE
add missing envvars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,6 +177,9 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       if: ${{ inputs.dry-run == 'false' && env.DEPLOY_METHOD == 'push' }}
+      env:
+        GIT_COMMIT_MESSAGE: ${{ inputs.git-commit-message }}
+        GIT_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
         if ! git diff --quiet origin/${DIFF_BRANCH} ; then
           if [ -n "${GIT_COMMIT_MESSAGE}" ]; then


### PR DESCRIPTION
Our commit messages only ever have the `skip-checks: true` line in them and never the original commit message. I'm hoping this is all that was missing, but it's hard to test b/c this action is nested in another. Let me know if you have ideas on how to test this properly.

It seems that this step doesn't have the envvars needed (removed non-public info)

```
 env:
    FULL_REF: refs/heads/main
    DEPLOY_REPO_URL: ***
    ENV_DIR: ***
    ENV_BRANCH: ***
    DIFF_BRANCH: ***
    ENV_BRANCH_URL: ***
    DEPLOY_METHOD: push
    PUSH_BRANCH: ***
    RUN_URL: ***
    DIFF_BRANCH_HEAD_SHA: ***
    DIFF_BRANCH_HEAD_SHORT_SHA: ***
    DIFF_BRANCH_HEAD_SHA_URL: ***
```