### PR TITLE
chore(deps): mega PR combining open renovate update PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: YAML Lint
-        uses: karancode/yamllint-github-action@v2.1.1
+        uses: karancode/yamllint-github-action@v3.0.0
         with:
           yamllint_comment: true
           yamllint_config_filepath: .github/config/yaml-linter.yaml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout Testing Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: kustomize-everything/test-deploy
@@ -54,7 +54,7 @@ jobs:
 
 
       - name: Checkout Testing Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: kustomize-everything/test-deploy
@@ -84,7 +84,7 @@ jobs:
           token: ${{ secrets.PUSHER_ROBOT_GITHUB_TOKEN }}
 
       - name: Checkout Testing Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: kustomize-everything/test-deploy
@@ -115,7 +115,7 @@ jobs:
           token: ${{ secrets.PUSHER_ROBOT_GITHUB_TOKEN }}
 
       - name: Checkout Testing Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: kustomize-everything/test-deploy

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         version: ${{ inputs.version }}
         sha256-checksum: ${{ inputs.sha256-checksum }}
 
-    - uses: azure/setup-helm@v4
+    - uses: azure/setup-helm@v5
       with:
         version: ${{ inputs.helm-version }}   # default is latest (stable)
       id: install
@@ -123,7 +123,7 @@ runs:
 
     - name: Find Comment
       if: github.event_name == 'pull_request'
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@v4
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -133,7 +133,7 @@ runs:
 
     - name: Create or update comment with No Changes
       if: ${{ github.event_name == 'pull_request' && steps.fc.outputs.comment-id != 0 && steps.diff.outputs.diff-bytes == 0 }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
@@ -146,7 +146,7 @@ runs:
 
     - name: Create or update comment with Diff
       if: ${{ github.event_name == 'pull_request' && steps.diff.outputs.diff-bytes > 0 && steps.diff.outputs.diff-bytes < 65000 }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
@@ -165,7 +165,7 @@ runs:
 
     - name: Create or update comment with Too Big Diff
       if: ${{ github.event_name == 'pull_request' && steps.diff.outputs.diff-bytes >= 65000 }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
@@ -198,7 +198,7 @@ runs:
 
     - name: Open Deployment PR to ${{ inputs.environment }}
       id: open-pr
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v8
       if: ${{ inputs.dry-run == 'false' && env.DEPLOY_METHOD == 'pull-request' && steps.diff.outputs.diff-bytes > 0 }}
       with:
         title: ${{ inputs.title || format('Deployment to {0}', inputs.environment) }}


### PR DESCRIPTION
Combines all currently open Renovate dependency-update PRs into a single PR so CI can validate them together.

## Included (superseded — can be closed once this merges)
- #55 chore(deps): update azure/setup-helm action to v5
- #54 chore(deps): update peter-evans/create-pull-request action to v8
- #53 chore(deps): update actions/checkout action to v6
- #52 chore(deps): update peter-evans/create-or-update-comment action to v5
- #51 chore(deps): update peter-evans/find-comment action to v4
- #48 chore(deps): update karancode/yamllint-github-action action to v3

## Left alone (contributor PRs, not touched by this PR)
- #40 (highb) PR test: base path
- #39 (odama626) add optional base path

## Verification
- `.github/workflows/linting.yml`, `static-analysis.yml`, and `test.yml` all trigger on `pull_request` to `main`, so GitHub Actions will run automatically against this PR to confirm nothing is broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4M9o6saae5zGmzEzZGrCb)_